### PR TITLE
format_rfc3339 use utc(), now() make it VERY slow

### DIFF
--- a/src/controller/cliente_controller.v
+++ b/src/controller/cliente_controller.v
@@ -57,7 +57,7 @@ pub fn (mut app ClienteCxt) post_transacao(idRequest int) vweb.Result {
 		valor: transacao_valor
 		tipo: transacao_dto.tipo
 		descricao: transacao_dto.descricao
-		realizada_em: time.now().format_rfc3339()
+		realizada_em: time.utc().format_rfc3339()
 	}
 
 	sql app.db {
@@ -102,7 +102,7 @@ pub fn (mut app ClienteCxt) get_extrato(idRequest i64) vweb.Result {
 	extrato_response_dto := dtos.ExtratoResponseDto{
 		saldo: dtos.SaldoDto{
 			total: cliente.saldo
-			data_extrato: time.now().format_rfc3339()
+			data_extrato: time.utc().format_rfc3339()
 			limite: cliente.limite
 		}
 		ultimas_transacoes: transacoes_response_dto


### PR DESCRIPTION
Se vc quiser algo ainda mais rápido, veja

```v
import benchmark

const max_iterations = 100_000

fn main() {
	mut b := benchmark.start()
	mut ts := C.timespec{}

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_REALTIME, &ts)
	}

	b.measure('CLOCK_REALTIME')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_REALTIME_COARSE, &ts)
	}

	b.measure('CLOCK_REALTIME_COARSE')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_MONOTONIC_COARSE, &ts)
	}

	b.measure('CLOCK_MONOTONIC_COARSE')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_MONOTONIC, &ts)
	}

	b.measure('CLOCK_MONOTONIC')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_MONOTONIC_RAW, &ts)
	}

	b.measure('CLOCK_MONOTONIC_RAW')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_BOOTTIME, &ts)
	}

	b.measure('CLOCK_BOOTTIME')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_PROCESS_CPUTIME_ID, &ts)
	}

	b.measure('CLOCK_PROCESS_CPUTIME_ID')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_THREAD_CPUTIME_ID, &ts)
	}

	b.measure('CLOCK_THREAD_CPUTIME_ID')

}
```
e https://github.com/vlang/v/pull/20317