### PR TITLE
ops

### DIFF
--- a/src/controller/cliente_controller.v
+++ b/src/controller/cliente_controller.v
@@ -79,7 +79,7 @@ pub fn (mut app ClienteCxt) get_extrato(idRequest i64) vweb.Result {
 	select from models.Cliente where id == idRequest
 	} or {panic(err)}
 
-	if clientes == [] {
+	if clientes.len == 0 {
 		app.set_status(404, '')
 		return app.text("")
 	}


### PR DESCRIPTION
Evitar criação desnecessária de array

`if (Array_src__models__Cliente_arr_eq(clientes, __new_array_with_default(0, 0, sizeof(src__models__Cliente), 0))) {`
ao invés de `if (clientes.len == 0) {`

Veja em `v -prod -o out.c .`